### PR TITLE
Release v0.0.10-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ name = dmz
 enabled = yes
 setup = no
 jump_host = dmz-jumphost.acme.org
+jump_port = 2222
 ```
 
 * `Socks:8881` instructs to create a local Socks proxy on port `8881`.
@@ -82,6 +83,7 @@ jump_host = dmz-jumphost.acme.org
 * `enabled` should the socks proxy be started or not. Accepts `yes` or `no`.
 * `setup` set to `yes` if the jumphost is used for the first time. Accepts `yes` or `no`
 * `jump_host` defines the termination point of the Socks proxy.
+* `jump_port` defines the port of `jump_host'`s connection, if ommited defaults to 22.
 
 
 ### Example LocalTunnel

--- a/src/PlinkProxy.ini-sample
+++ b/src/PlinkProxy.ini-sample
@@ -76,14 +76,15 @@ target_port  = 636
 ; the only one being executed when the [Setup Proxies] button is pressed.
 ; After setup has been conducted change the value to `no`. The simplified
 ; plink command finally executed looks like the one below. 
-; `plink -proxycmd "plink -nc admin.dmz.sample.net:22 joedoe@admin.sample.net" ^
-;    -L 12443:ldap.dmz.sample.net:443 joedoe@admin.dmz.sample.net`
+; `plink -proxycmd "plink -nc admin.dmz.sample.net:2222 joedoe@admin.sample.net" ^
+;    -L 12443:ldap.dmz.sample.net:443 -P 2222 joedoe@admin.dmz.sample.net`
 ; In the local webbrowser use 'https://localhost:12443/' to connect to the 
 ; web server
 name = dmz-http
 enabled = yes
 setup = yes
 jump_host = admin.dmz.sample.net
+jump_port = 2222
 target_host = www.dmz.sample.net
 target_port = 443
 

--- a/src/Version.au3
+++ b/src/Version.au3
@@ -1,7 +1,7 @@
 ; ---------------------------------------------------------------------------------
 ; Version file used by the make, packaging and compile tools
 ; ---------------------------------------------------------------------------------
-Global Const $VERSION       = "0.0.9-alpha"
+Global Const $VERSION       = "0.0.10-alpha"
 Global Const $VERSION_MAJOR = (StringSplit($VERSION, '.-'))[1]
 Global Const $VERSION_MINOR = (StringSplit($VERSION, '.-'))[2]
 Global Const $VERSION_PATCH = (StringSplit($VERSION, '.-'))[3]


### PR DESCRIPTION
Summary:
  * Bugfix fatal error preventing Socks connection from being
    established
  * Adding new configuration option `jump_port` to specify a port
    should an ssh connection be a different port than `22`.
  * Allow the `jump_host` to be `localhost , `127.0.0.1` or '::1`
    when a connection is forwarded to an other incoming ssh tunnel.
    requires the `jump_port` to be set.